### PR TITLE
fix the version pattern check for Vim 7.x

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -47,7 +47,7 @@ function getVersion(neovim: boolean): string {
         return l;
     }
 
-    const re = neovim ? /^v\d+\.\d+\.\d+$/ : /^v\d+\.\d+\.\d{4}$/;
+    const re = neovim ? /^v\d+\.\d+\.\d+$/ : /^v7\.\d+(?:\.\d+)?$|^v\d+\.\d+\.\d{4}$/;
     if (!re.test(v)) {
         const repo = neovim ? 'neovim/neovim' : 'vim/vim';
         throw new Error(

--- a/test/config.ts
+++ b/test/config.ts
@@ -57,6 +57,14 @@ describe('loadConfigFromInputs()', function() {
             version: 'v10.10.0001',
         },
         {
+            neovim: false,
+            version: 'v7.4.100',
+        },
+        {
+            neovim: false,
+            version: 'v7.4',
+        },
+        {
             neovim: true,
             version: 'v0.4.3',
         },


### PR DESCRIPTION
Current version check does not allow checkout [v7.4.100](https://github.com/vim/vim/tree/v7.4.100), or [v7.4](https://github.com/vim/vim/tree/v7.4). I'm not sure how many people use these legacy versions (maybe I will), but there are actually tags so throwing an exception is not correct.