### PR TITLE
fix neovim macos asset dir name

### DIFF
--- a/src/neovim.ts
+++ b/src/neovim.ts
@@ -22,8 +22,15 @@ function assetFileName(os: Os): string {
 
 export function assetDirName(version: string, os: Os): string {
     switch (os) {
-        case 'macos':
-            return 'nvim-osx64';
+        case 'macos': {
+            // Until v0.7.0 release, 'nvim-osx64' was the asset directory name on macOS. However it was changed to 'nvim-macos'
+            // from v0.7.1.
+            const m = version.match(/^v0\.(\d+)\.(\d+)$/);
+            if ((m !== null && parseInt(m[1]) < 7) || (m !== null && parseInt(m[1]) === 7 && parseInt(m[2]) < 1)) {
+                return 'nvim-osx64';
+            }
+            return 'nvim-macos';
+        }
         case 'linux':
             return 'nvim-linux64';
         case 'windows': {

--- a/test/neovim.ts
+++ b/test/neovim.ts
@@ -116,14 +116,23 @@ describe('Neovim installation', function () {
     });
 
     describe('assetDirName', function () {
-        it('returns "Neovim" when Neovim version is earlier than 0.7', function () {
+        it('returns "Neovim" when Neovim version is earlier than 0.7 on Windows', function () {
             A.equal(assetDirName('v0.6.1', 'windows'), 'Neovim');
             A.equal(assetDirName('v0.4.3', 'windows'), 'Neovim');
         });
-        it('returns "Neovim" when Neovim version is 0.7 or later', function () {
+        it('returns "Neovim" when Neovim version is 0.7 or later on Windows', function () {
             A.equal(assetDirName('v0.7.0', 'windows'), 'nvim-win64');
             A.equal(assetDirName('v0.10.0', 'windows'), 'nvim-win64');
             A.equal(assetDirName('v1.0.0', 'windows'), 'nvim-win64');
+        });
+        it('returns "nvim-osx64" when Neovim version is earlier than 0.7.1 on macOS', function () {
+            A.equal(assetDirName('v0.7.0', 'macos'), 'nvim-osx64');
+            A.equal(assetDirName('v0.6.1', 'macos'), 'nvim-osx64');
+        });
+        it('returns "nvim-macos" when Neovim version is 0.7.1 or later on macOS', function () {
+            A.equal(assetDirName('v0.7.1', 'macos'), 'nvim-macos');
+            A.equal(assetDirName('v0.10.0', 'macos'), 'nvim-macos');
+            A.equal(assetDirName('v1.0.0', 'macos'), 'nvim-macos');
         });
     });
 });


### PR DESCRIPTION
Current macos neovim asset directory was changed from https://github.com/neovim/neovim/pull/19029 .
This pr follows the change.

📝
- https://github.com/neovim/neovim/commits/v0.7.1 includes the commit.
- https://github.com/neovim/neovim/commits/v0.7.0 does not includes the commit.
