### PR TITLE
fix: macos nightly build filename since #28000

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
     name: Check unit tests and linter
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest, macos-14]
+        os: [ubuntu-latest, macos-latest, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,10 @@ jobs:
 
   test-and-lint:
     name: Check unit tests and linter
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest, macos-14]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/src/neovim.ts
+++ b/src/neovim.ts
@@ -12,12 +12,14 @@ import type { Installed } from './install';
 function assetFileName(os: Os, version: string): string {
     switch (os) {
         case 'macos':
-            if (version == 'nightly') {
+            if (version === 'nightly') {
                 switch (process.arch) {
                     case 'arm64':
                         return 'nvim-macos-arm64.tar.gz';
                     case 'x64':
                         return 'nvim-macos-x86_64.tar.gz';
+                    default:
+                        break;
                 }
             }
             return 'nvim-macos.tar.gz';
@@ -56,12 +58,14 @@ export function assetDirName(version: string, os: Os): string {
             }
             // Until v0.9.5 release, 'nvim-macos' was the asset directory name on macOS. However it was changed to 'nvim-macos-arm64'
             // and 'nvim-macos-x86_64' from v0.10.0: https://github.com/neovim/neovim/pull/28000
-            if (version == 'nightly') {
+            if (version === 'nightly') {
                 switch (process.arch) {
                     case 'arm64':
                         return 'nvim-macos-arm64';
                     case 'x64':
                         return 'nvim-macos-x86_64';
+                    default:
+                        break;
                 }
             }
             return 'nvim-macos';

--- a/test/neovim.ts
+++ b/test/neovim.ts
@@ -138,7 +138,16 @@ describe('Neovim installation', function () {
             A.equal(assetDirName('v0.7.1', 'macos'), 'nvim-macos');
             A.equal(assetDirName('v0.10.0', 'macos'), 'nvim-macos');
             A.equal(assetDirName('v1.0.0', 'macos'), 'nvim-macos');
-            A.equal(assetDirName('nightly', 'macos'), 'nvim-macos');
+            switch (process.arch) {
+                case 'arm64':
+                    A.equal(assetDirName('nightly', 'macos'), 'nvim-macos-arm64');
+                    break;
+                case 'x64':
+                    A.equal(assetDirName('nightly', 'macos'), 'nvim-macos-x86_64');
+                    break;
+                default:
+                    A.equal(assetDirName('nightly', 'macos'), 'nvim-macos');
+            }
             A.equal(assetDirName('stable', 'macos'), 'nvim-macos');
         });
     });


### PR DESCRIPTION
Fix #30 .

This PR fixes the nightly nvim asset filename for macOS, since https://github.com/neovim/neovim/pull/28000, Neovim nightly build on macOS is renamed from 'nvim-macos.tar.gz' to 'nvim-macos-arm64.tar.gz' and 'nvim-macos-x86_64.tar.gz'.

But seems I cannot test this PR with my forked repo: https://github.com/linrongbin16/action-setup-vim/tree/fix-macos-nightly, I'm blocked for now, will try to test it.

----------------

Update: this PR is tested here: https://github.com/linrongbin16/action-setup-vim/pull/1