### PR TITLE
Update for new Neovim Linux package and directory names

### DIFF
--- a/src/neovim.ts
+++ b/src/neovim.ts
@@ -43,7 +43,18 @@ function assetFileName(os: Os, version: string): string {
             }
         }
         case 'linux':
-            return 'nvim-linux64.tar.gz';
+            const v = parseVersion(version);
+            if (v !== null && v.minor <= 10 && v.patch <= 3) {
+                return 'nvim-linux64.tar.gz';
+            }
+            switch (process.arch) {
+                case 'arm64':
+                    return 'nvim-linux-arm64.tar.gz';
+                case 'x64':
+                    return 'nvim-linux-x86_64.tar.gz';
+                default:
+                    throw Error(`Unsupported arch for Neovim ${version} on ${os}: ${process.arch}`); // Should be unreachable
+            }
         case 'windows':
             return 'nvim-win64.zip';
     }
@@ -75,7 +86,18 @@ export function assetDirName(version: string, os: Os): string {
             }
         }
         case 'linux':
-            return 'nvim-linux64';
+            const v = parseVersion(version);
+            if (v !== null && v.minor <= 10 && v.patch <= 3) {
+                return 'nvim-linux64';
+            }
+            switch (process.arch) {
+                case 'arm64':
+                    return 'nvim-linux-arm64';
+                case 'x64':
+                    return 'nvim-linux-x86_64';
+                default:
+                    throw Error(`Unsupported arch for Neovim ${version} on ${os}: ${process.arch}`); // Should be unreachable
+            }
         case 'windows': {
             // Until v0.6.1 release, 'Neovim' was the asset directory name on Windows. However it was changed to 'nvim-win64'
             // from v0.7.0. (#20)


### PR DESCRIPTION
As of [Neovim 0.10.4](https://github.com/neovim/neovim/releases/tag/v0.10.4), the following changes have been made:

> A Linux AArch64 binary has been added as part of the binary releases.
> In addition, the previous "linux64" binary has been renamed to "linux-x86_64".
> This is a BREAKING change for scripts which consumes our binary releases.

This updates the neovim installation to work with the new linux naming scheme, using the same pattern that's currently used for macos package and directory names.

I created [a branch](https://github.com/danarnold/action-setup-vim/tree/neovim-0.10.4) with the same changes applied to a release tag of this action and I've used it to install the latest neovim, which is currently failing on the version without these changes.